### PR TITLE
Use correct Apache Maven Path when build ONOS

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,4 +1,4 @@
-[onos-onossystemtest]
-master_template ansible_host=10.211.55.121
+[onos-master]
+master_template
 
 [onos-slave]

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: onos-master
+  sudo: yes
   vars_files:
     - group_vars/version.yml
     - group_vars/config.yml

--- a/roles/onos/tasks/main.yml
+++ b/roles/onos/tasks/main.yml
@@ -15,7 +15,7 @@
   tags: onos
 
 - name: Build ONOS
-  command: "mvn clean install"
   args:
     chdir: "{{ ONOS_ROOT }}"
+  command: "{{ M2_HOME }}/bin/mvn clean install"
   tags: onos


### PR DESCRIPTION
1. Use correct Apache Maven Path when build ONOS
2. Revise some Ansible attributes
